### PR TITLE
remove deoplete and deoplete-go

### DIFF
--- a/nvim-linux/.config/nvim/coc-settings.json
+++ b/nvim-linux/.config/nvim/coc-settings.json
@@ -1,0 +1,9 @@
+{
+  "languageserver":{
+    "golang": {
+      "command": "gopls",
+      "rootPatterns": ["go.mod", ".vim/", ".git/", ".hg/"],
+      "filetypes": ["go"]
+    }
+  }
+}

--- a/nvim-linux/.config/nvim/golang.vim
+++ b/nvim-linux/.config/nvim/golang.vim
@@ -33,3 +33,19 @@ let g:go_snippet_engine = "neosnippet"
 au FileType go nmap <Leader>ga :GoAddTags<cr>
 " \gt : パッケージ内の関数や型の定義元一覧, ctrlpで表示
 au FileType go nmap <Leader>gt :GoDeclsDir<cr>
+
+" ----- lsp settings
+" Need to install golsp. using "go get -u golang.org/x/tools/cmd/gopls" command.
+
+" for vim-go and gopls. See: https://github.com/golang/go/wiki/gopls
+"let g:go_def_mode='gopls'
+
+" for coc.nvim and gopls. See: https://github.com/neoclide/coc.nvim/wiki/Language-servers#go
+" Run ":CocConfig" command and edit json as follows
+  " "languageserver": {
+  "   "golang": {
+  "     "command": "gopls",
+  "     "rootPatterns": ["go.mod", ".vim/", ".git/", ".hg/"],
+  "     "filetypes": ["go"]
+  "   }
+  " }

--- a/nvim-linux/.config/nvim/plug.vim
+++ b/nvim-linux/.config/nvim/plug.vim
@@ -43,12 +43,22 @@ Plug 'tpope/vim-rails'
 Plug 'thoughtbot/vim-rspec'
 
 " completion
+" coc.nvim with LSP
+"" - 1st, :Cocinstall coc-gocode  " for golang. See: https://www.npmjs.com/package/coc-gocode
+"" - 2nd, and edit coc config using :CocConfig command. See: https://github.com/neoclide/coc.nvim/wiki/Language-servers#go
+"" - 3rd, and install gopls using go get -u golang.org/x/tools/cmd/gopls
+Plug 'neoclide/coc.nvim', {'tag': '*', 'do': './install.sh'}
+
 Plug 'mattn/emmet-vim'  "zencodingの記法でHTMLやCSSの構造を書き, 「C-Y ,」でそれを展開 http://motw.mods.jp/Vim/emmet-vim.html
-Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
-Plug 'zchee/deoplete-go', { 'do': 'make'}  "require: go get -u github.com/nsf/gocode
+"Plug 'Shougo/deoplete.nvim', { 'do': ':UpdateRemotePlugins' }
+"Plug 'deoplete-plugins/deoplete-go', { 'do': 'make'}  "require: go get -u github.com/mdempsky/gocode
 Plug 'Shougo/neosnippet.vim'
 Plug 'Shougo/neosnippet-snippets'
 Plug 'Shougo/neomru.vim'
-Plug 'ternjs/tern_for_vim', { 'do': 'npm install && npm install -g tern' } "https://vimawesome.com/plugin/tern-for-vim-state-of-grace
+"Plug 'ternjs/tern_for_vim', { 'do': 'npm install && npm install -g tern' } "https://vimawesome.com/plugin/tern-for-vim-state-of-grace
+
+" for go with vim-lsp (and gopls)
+" Plug 'prabirshrestha/async.vim'
+" Plug 'prabirshrestha/vim-lsp'
 
 call plug#end()

--- a/setup.sh
+++ b/setup.sh
@@ -139,7 +139,6 @@ fi
 if [ -x ${GOROOT}/bin/go ]
 then
   PATH=${GOROOT}/bin:${PATH}
-  go get -v github.com/nsf/gocode
   go get -v github.com/golang/lint
   go get -v -u github.com/golang/lint/golint
   go get -v -u golang.org/x/tools/cmd/goimports
@@ -148,6 +147,8 @@ then
   go get -v github.com/peco/peco/cmd/peco
   go get -v -u github.com/mgechev/revive
   go get -v -u gopkg.in/alecthomas/gometalinter.v2
+  go get -v github.com/mdempsky/gocode # TODO: out of date, us gopls for go completion
+  go get -v -u golang.org/x/tools/cmd/gopls
 fi
 
 ## run ex commands


### PR DESCRIPTION
Since updated `vim-go` plugin by `:PlugUpdate` command, `deoplete` and `deoplete-go` does not work.
So I'm finding a PLAN B.